### PR TITLE
Removed "Cabron"

### DIFF
--- a/es
+++ b/es
@@ -2,7 +2,6 @@ Asesinato
 asno
 bastardo
 Bollera
-Cabron
 Cabrón
 Caca
 Chupada


### PR DESCRIPTION
"Cabrón" is only correctly written with a tilde on the "ó", "cabron" means nothing other than a spelling error so I believe it shouldn't be here. these are bad words, not poorly written ones