### PR TITLE
Remove non-offensive words from the french list

### DIFF
--- a/fr
+++ b/fr
@@ -5,7 +5,6 @@ bite
 bitte
 bloblos
 bordel
-bosser
 bourré
 bourrée
 brackmard
@@ -16,7 +15,6 @@ branleur
 branleuse
 brouter le cresson
 caca
-cailler
 chatte
 chiasse
 chier
@@ -32,7 +30,6 @@ cramouille
 cul
 déconne
 déconner
-drague
 emmerdant
 emmerder
 emmerdeur
@@ -84,12 +81,10 @@ suce
 tapette
 tanche
 teuch
-teuf
 tringler
 trique
 troncher
 trou du cul
 turlute
-veuve
 zigounette
 zizi


### PR DESCRIPTION
veuve means widow, it is not even colloquial

bosser means "to work", it's very common : https://en.wiktionary.org/wiki/bosser#French
cailler means "to curdle", it can be used in slang with the meaning "to be very cold" : https://en.wiktionary.org/wiki/cailler#French
drague is a colloquial word that means "seduction" : https://en.wiktionary.org/wiki/drague#French
These words are commonly used in mainstream media, and not offensive.

teuf means party, it's slang but not offensive