### PR TITLE
Add 3 racist and anti-disability slurs

### DIFF
--- a/en
+++ b/en
@@ -213,6 +213,7 @@ masturbate
 menage a trois
 milf
 missionary position
+mong
 motherfucker
 mound of venus
 mr hands
@@ -249,6 +250,7 @@ pegging
 penis
 phone sex
 piece of shit
+pikey
 pissing
 piss pig
 pisspig
@@ -311,6 +313,7 @@ snatch
 snowballing
 sodomize
 sodomy
+spastic
 spic
 splooge
 splooge moose


### PR DESCRIPTION
Add a slur for irish and travellers, and a racist anti-downs syndrome slur, and a slur directed at people with cerebral palsy

## Mong

There was a theory that people with downs syndrome were due to mixed breeding between races, specifically mongolians, and that people with downs syndrome must have mongolian ancestry if you dig far back enough.

> The word “mong” derives from the word “mongol” and “mongoloid”. Dr. John Langdon Down, who discovered Down’s syndrome in the 1860s, used “mongolism” and “mongoloid” to describe the syndrome as he stated that there were similar physical characteristics of people with Down’s syndrome to people from Mongolia and Mongoloid race (those of Asian ethnicity). This phrase was used until the 1960s, when scientists petitioned to use “Down’s syndrome” instead of “Mongolism” or “Mongoloid” as they were embarrassing terms for Chinese and Japanese scientists and academics to use this word to refer to the syndrome.

References:
 - https://english.stackexchange.com/questions/67258/mongoloid-with-reference-to-downs-syndrome
 - https://en.wikipedia.org/wiki/Down_syndrome#Name

## Pikey

An ethnic racist slur directed at the travelling community and the Irish, mainly used in the UK and Ireland

 - https://en.wikipedia.org/wiki/Pikey

## Spastic

Used originally to describe those with cerebral palsy but become a derogatory insult in the UK, widely considered an offensive slur against disabled people in the UK, it lead to Mario Party 8 being recalled in the UK

https://en.wikipedia.org/wiki/Spastic#UK_and_Ireland